### PR TITLE
Use the globally installed micro instead of a shipped one

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@
 
 Run multiple `micro` servers and a front proxy at a time, with a simple configuration file.
 
+## Installation
+
+```console
+$ npm install -g micro
+
+$ npm install -g micro-cluster
+```
+
 ## Example
 
 Create a config file like the following.

--- a/bin/micro-cluster
+++ b/bin/micro-cluster
@@ -49,7 +49,7 @@ async function main() {
     const port = service.port || await getPort()
 
     const opts = {env, stdio: 'inherit', customFds: [0, 1, 2]}
-    await spawn(resolve(__dirname, 'micro'), ['--port', port, path], opts)
+    await spawn('micro', ['--port', port, path], opts)
     services.set(id, port)
   }
 


### PR DESCRIPTION
Should the "micro" be shipped with "micro-cluster" ? If installed separetly (globally), it can be easily kept up-to-date.